### PR TITLE
set and unset activeTransaction flag on databaseConnection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@loyaltylion/typeorm",
   "private": true,
-  "version": "0.2.10-3",
+  "version": "0.2.10-4",
   "description": "loyaltylion fork",
   "license": "MIT",
   "readmeFilename": "README.md",

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -120,6 +120,10 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
 
         this.isTransactionActive = true;
         await this.query("START TRANSACTION");
+        // in remus, the LL postgres client checks if it's in a transaction
+        // using this field, if typeorm doesn't set/unset it we can wind up
+        // where legacy code thinks a transaction is active when it's really not
+        this.databaseConnection.activeTransaction = true;
         if (isolationLevel) {
             await this.query("SET TRANSACTION ISOLATION LEVEL " + isolationLevel);
         }
@@ -135,6 +139,10 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
 
         await this.query("COMMIT");
         this.isTransactionActive = false;
+        // in remus, the LL postgres client checks if it's in a transaction
+        // using this field, if typeorm doesn't set/unset it we can wind up
+        // where legacy code thinks a transaction is active when it's really not
+        this.databaseConnection.activeTransaction = false;
     }
 
     /**
@@ -147,6 +155,10 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
 
         await this.query("ROLLBACK");
         this.isTransactionActive = false;
+        // in remus, the LL postgres client checks if it's in a transaction
+        // using this field, if typeorm doesn't set/unset it we can wind up
+        // where legacy code thinks a transaction is active when it's really not
+        this.databaseConnection.activeTransaction = false;
     }
 
     /**


### PR DESCRIPTION
LL specific change - our legacy services use this field to determine
if a transaction is active or not, if we don't manage it via
typeorm then it's possible legacy clients will still think they
are in a transaction when they're not